### PR TITLE
Fix memory cleanup for image widgets

### DIFF
--- a/qt_image_to_pdf.py
+++ b/qt_image_to_pdf.py
@@ -162,9 +162,13 @@ class ImageToPDFApp(QWidget):
         if label in self.image_labels:
             self.image_labels.remove(label)
             label.setParent(None)
+            label.deleteLater()
             self.refresh_grid()
 
     def clear_images(self):
+        for label in self.image_labels:
+            label.setParent(None)
+            label.deleteLater()
         self.image_labels = []
         self.refresh_grid()
 


### PR DESCRIPTION
## Summary
- free label memory when removing single image
- free label memory when clearing all images

## Testing
- `python -m py_compile qt_image_to_pdf.py`


------
https://chatgpt.com/codex/tasks/task_e_684974f26c8c832fa93d4abdb39623c6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup of image labels when removing individual images or clearing all images, ensuring better performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->