### PR TITLE
Fix drag reorder logic

### DIFF
--- a/qt_image_to_pdf.py
+++ b/qt_image_to_pdf.py
@@ -155,6 +155,8 @@ class ImageToPDFApp(QWidget):
         if source in self.image_labels and target in self.image_labels:
             src_idx = self.image_labels.index(source)
             tgt_idx = self.image_labels.index(target)
+            if src_idx < tgt_idx:
+                tgt_idx -= 1
             self.image_labels.insert(tgt_idx, self.image_labels.pop(src_idx))
             self.refresh_grid()
 


### PR DESCRIPTION
## Summary
- ensure dragged image occupies dropped position

## Testing
- `python3 -m py_compile qt_image_to_pdf.py`


------
https://chatgpt.com/codex/tasks/task_e_684974e79294832f99d6b9b8a35e161e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the drag-and-drop reordering of images to ensure correct placement when moving images forward in the list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->