### PR TITLE
Remove unused PIL import

### DIFF
--- a/qt_image_to_pdf.py
+++ b/qt_image_to_pdf.py
@@ -6,7 +6,6 @@ from PyQt5.QtWidgets import (
 )
 from PyQt5.QtGui import QPixmap, QDrag
 from PyQt5.QtCore import Qt, QMimeData, QPoint, QEvent, QCoreApplication
-from PIL import Image
 import img2pdf
 from threading import Thread
 


### PR DESCRIPTION
## Summary
- drop unused PIL import from `qt_image_to_pdf.py`

## Testing
- `python -m py_compile qt_image_to_pdf.py`

------
https://chatgpt.com/codex/tasks/task_e_68497486a91c832f88e12b28d7824a92

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed an unused import to streamline the application. No impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->