### PR TITLE
Add PDF import and merging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Created out of frustration with online tools — and a whole lotta love 🧡
 ## ✨ Features
 
 - 🔼 Drag and drop image files (JPG, PNG, WebP, BMP, etc.)
+- ➕ Import entire PDFs and edit page order
 - 📄 Reorder thumbnails before exporting
 - 💾 Export as **one high-quality PDF**
 - 🚫 Works **100% offline** – no internet, no tracking, no compression

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 PyQt5>=5.15.0
 img2pdf>=0.4.0
 Pillow>=9.0.0
+pypdf>=3.0.0
+pdf2image>=1.16.0


### PR DESCRIPTION
## Summary
- add `pypdf` and `pdf2image` dependencies
- allow importing PDF files and reorder their pages
- generate previews for PDF pages
- merge images and PDF pages into one PDF
- document PDF editing support in README

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile qt_image_to_pdf.py`


------
https://chatgpt.com/codex/tasks/task_e_685fa7fb0ae0832fbcf65ff78f46a390

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to import entire PDFs and edit the order of their pages alongside images.
  * Users can now merge images and PDF pages into a single PDF export.

* **Documentation**
  * Updated the README to include the new PDF import and page reordering feature.

* **Chores**
  * Added new dependencies required for PDF import and export functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->